### PR TITLE
rea-rs-low: update to Cargo.toml and build.rs in order to pretty print the generated reaper.rs

### DIFF
--- a/low/Cargo.toml
+++ b/low/Cargo.toml
@@ -32,7 +32,7 @@ generate = ["generate-stage-one", "generate-stage-two"]
 generate-stage-one = ["generate-stage-two", "bindgen"]
 
 # Stage 2 can run separately.
-generate-stage-two = ["quote", "syn", "proc-macro2", "phf"]
+generate-stage-two = ["quote", "prettyplease", "syn", "proc-macro2", "phf"]
 
 [dependencies]
 c_str_macro = "1.0.2"
@@ -55,4 +55,5 @@ cc = "1.0.65"
 phf = {version = "0.8", features = ["macros"], optional = true}
 proc-macro2 = {version = "1.0.8", optional = true}
 quote = {version = "1.0.2", optional = true}
+prettyplease = {version="0.1.25", optional = true}
 syn = {version = "1.0.14", features = ["full"], optional = true}

--- a/low/build.rs
+++ b/low/build.rs
@@ -398,8 +398,12 @@ mod codegen {
         /// Generates the `reaper.rs` file from the previously generated
         /// `bindings.rs`
         fn generate_reaper(file: &syn::File) {
-            let fn_ptrs = parse_fn_ptrs(file, "reaper_functions");
-            let result = generate_reaper_token_stream(&fn_ptrs);
+            let result = {
+                let fn_ptrs = parse_fn_ptrs(file, "reaper_functions");
+                let result = generate_reaper_token_stream(&fn_ptrs);
+                let syntax_tree =  syn::parse_file(result.to_string().as_str()).unwrap();
+                prettyplease::unparse(&syntax_tree)
+            };
             std::fs::write("src/reaper.rs", result.to_string())
                 .expect("Unable to write file");
         }


### PR DESCRIPTION
note: I used an old version of `prettyplease`, that matches `syn`, otherwise it seems more complicated to get what I wanted 🙂.